### PR TITLE
Fixed paypal button callback function

### DIFF
--- a/hosted-fields/public/buttons.js
+++ b/hosted-fields/public/buttons.js
@@ -12,7 +12,7 @@ paypal
     },
     // Sets up the transaction when a payment button is clicked
     createOrder(data, actions) {
-      return api.createOrder();
+      return api.createOrder().id;
     },
     // Finalize the transaction after payer approval
     async onApprove(data, actions) {


### PR DESCRIPTION
`createOrder` is expects to return an order ID, not the whole json